### PR TITLE
Fix dependabot.yml file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+updates:
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
Removed too many lines when editing from the configuration file example in literacyfootprints.

Adding `updates:` line

Incorrectly landed configuration in https://github.com/Pioneer-Valley-Books/postcss-dvh-vh-fallback/commit/651993ba38e5abb9aebe9ceaddbefab310b9b7ec